### PR TITLE
Nextification

### DIFF
--- a/src/Feed/Feed.js
+++ b/src/Feed/Feed.js
@@ -1,128 +1,35 @@
-import React from 'react';
+import { GET_ALL_POSTS } from '../requests.js'
+import React, { useState } from 'react';
 import '../Scss/base.scss';
+import { gql, useQuery } from '@apollo/client';
 import { Post } from '../Post/Post.js';
 
 export default function Feed(props) {
-    let theArray = [
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-        <Post 
-        myPostsPage={props.myPostsPage}
-        content={props.content}
-        lat={props.lat}
-        lon={props.lon}
-        name={props.name}
-        icon={props.icon}
-        ring={props.ring}
-        date={props.date}
-        lastLike={props.lastLike}
-        />,
-    ];
+    let [postIndex, setPostIndex] = useState(0)
+    let {loading, error, data } = useQuery(GET_ALL_POSTS);
+
+    if (loading) {
+      return (<h1>LOADING POSTS...</h1>)
+    }
+
+    function addToIndex(num) {
+      let arrLength = data.posts.length
+      let total = num + postIndex
+      let index = ((total % arrLength) + arrLength) % arrLength
+      return index
+    }
+
+    console.log(data)
+
+    let { content, createdAt, id, ringMinMax } = data.posts[postIndex]
+    let [min, max] = ringMinMax.slice(1, -1).split(', ').map( char => +char )
+
     return (
         <section className='feed'>
             <h1 className='header-title'>{props.headerTitle}</h1>
-            {
-                theArray.map(i => {
-                    return i;
-                })
-            }
+            <Post content={content} createdAt={createdAt} id={id} ring={[min, max]}/>
+            <button onClick={ () => setPostIndex( addToIndex( -1 )) }>Previous</button>
+            <button onClick={ () => setPostIndex( addToIndex( 1 )) }>Next</button>
         </section>
     )
 }

--- a/src/Post/Post.js
+++ b/src/Post/Post.js
@@ -1,5 +1,6 @@
 import blueLike from '../images/like-blue.png';
 import { CREATE_LIKE } from '../requests';
+import dummyIcon from '../images/dummyIcon.png'
 import defaultLike from '../images/like-white.png';
 import React, { useState }  from 'react';
 import { useMutation } from '@apollo/client';
@@ -7,16 +8,16 @@ import '../Scss/base.scss';
 
 export function Post(props) {
     let [userInfo, setUserInfo] = useState({
-        userIcon: null,
+        userIcon: dummyIcon,
         name: null,
         id: 10
     })
     let [postInfo, setPostInfo] = useState({
-        ring: 0,
-        id: 14,
-        date: null,
-        liked: false,
-        postContent: null,
+        ring: props.ring,
+        id: props.id,
+        createdAt: props.createdAt,
+        liked: props.liked,
+        content: props.content,
     })
     let [page, setPage] = useState({
         myPosts: true
@@ -103,8 +104,8 @@ export function Post(props) {
                 <section className='post-right'>
                     <div className='post-right-top'>
                             <em><strong><h5 className='post-right-top-h' id='name-header'>{props.name}</h5></strong></em><br/>
-                            <em><h6 className='post-right-top-h' id='prt2'>Ring: {props.ring}</h6></em><br/>
-                            <em><h6 className='post-right-top-h' id='prt3'>Date: {props.date}</h6></em>
+                            <em><h6 className='post-right-top-h' id='prt2'>Ring: {props.ring[1]}</h6></em><br/>
+                            <em><h6 className='post-right-top-h' id='prt3'>Date: {props.createdAt}</h6></em>
                     </div>
                     <div className='post-right-bottom'>
                         <p className='post-right-bottom-p'>{props.content}</p>


### PR DESCRIPTION
Redesign `Feed` layout to incorporate new display style and to load posts from the backend
### Description

Feed now loads Posts from the backend. After a successful fetch, posts are in an array. The Post at 0 is displayed by default, but the the `Next` and `Prev` buttons cycle posts one in either direction.

### Related Issue

closes #28
### Motivation and Context

New design layout was impelled by our desire to make a visual lure, which will incorporate a map API
### How Has This Been Tested?

In the browser
### Screenshots (if appropriate):
### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
### Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
